### PR TITLE
chore(deps): bump https://github.com/jenkins-x-labs/step-go-releaser.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,3 +4,4 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [jenkins-x-labs/jxl](https://github.com/jenkins-x-labs/jxl.git) |  | []() | 
 [jenkins-x-labs/helmboot](https://github.com/jenkins-x-labs/helmboot.git) |  | []() | 
+[jenkins-x-labs/step-go-releaser](https://github.com/jenkins-x-labs/step-go-releaser.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -11,3 +11,9 @@ dependencies:
   url: https://github.com/jenkins-x-labs/helmboot.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: jenkins-x-labs
+  repo: step-go-releaser
+  url: https://github.com/jenkins-x-labs/step-go-releaser.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/jenkins-x-labs-step-go-releaser-sr.yaml
+++ b/repositories/templates/jenkins-x-labs-step-go-releaser-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jenkins-x-labs
+    provider: github
+    repository: step-go-releaser
+  name: jenkins-x-labs-step-go-releaser
+spec:
+  description: Imported application for jenkins-x-labs/step-go-releaser
+  httpCloneURL: https://github.com/jenkins-x-labs/step-go-releaser.git
+  org: jenkins-x-labs
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: step-go-releaser
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jenkins-x-labs/step-go-releaser.git


### PR DESCRIPTION
Update [jenkins-x-labs/step-go-releaser](https://github.com/jenkins-x-labs/step-go-releaser.git) 

Command run was `jxl project import --url https://github.com/jenkins-x-labs/step-go-releaser --no-pack`